### PR TITLE
Color workout type chips by phase accent

### DIFF
--- a/src/app/build.tsx
+++ b/src/app/build.tsx
@@ -15,7 +15,7 @@ import SectionLabel from '@/components/shared/SectionLabel';
 import SummaryCard from '@/components/shared/SummaryCard';
 import CTAButton from '@/components/shared/CTAButton';
 import GradientScreen from '@/components/shared/GradientScreen';
-import TypeChip from '@/components/shared/TypeChip';
+import TypeChip, { ChipAccent } from '@/components/shared/TypeChip';
 import WorkoutTypeIcon from '@/components/shared/WorkoutTypeIcon';
 
 const DEFAULT: Preset = {
@@ -26,11 +26,11 @@ const DEFAULT: Preset = {
   prepSecs: 10, warmupSecs: 0, cooldownSecs: 0,
 };
 
-const TYPES: { key: WorkoutType; label: string }[] = [
-  { key: 'hiit',     label: 'HIIT' },
-  { key: 'running',  label: 'Running' },
-  { key: 'cardio',   label: 'Cardio' },
-  { key: 'strength', label: 'Strength' },
+const TYPES: { key: WorkoutType; label: string; accent: ChipAccent }[] = [
+  { key: 'hiit',     label: 'HIIT',     accent: 'work' },
+  { key: 'running',  label: 'Running',  accent: 'prep' },
+  { key: 'cardio',   label: 'Cardio',   accent: 'prep' },
+  { key: 'strength', label: 'Strength', accent: 'rest' },
 ];
 
 export default function BuildScreen() {
@@ -66,16 +66,17 @@ export default function BuildScreen() {
         <View style={styles.section}>
           <SectionLabel style={styles.sectionLabelSpacing}>Type</SectionLabel>
           <View style={styles.typeGrid}>
-            {TYPES.map(({ key, label }) => (
+            {TYPES.map(({ key, label, accent }) => (
               <TypeChip
                 key={key}
                 label={label}
+                accent={accent}
                 selected={p.type === key}
                 onPress={() => update({ type: key })}
                 icon={
                   <WorkoutTypeIcon
                     type={key}
-                    color={p.type === key ? Colors.work : Colors.textLo}
+                    color={p.type === key ? Colors[accent] : Colors.textLo}
                   />
                 }
               />

--- a/src/components/shared/TypeChip.tsx
+++ b/src/components/shared/TypeChip.tsx
@@ -2,22 +2,37 @@ import React from 'react';
 import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native';
 import { Colors, FontSizes, Radii } from '@/constants/theme';
 
+export type ChipAccent = 'work' | 'prep' | 'rest' | 'strength';
+
+const ACCENT_STYLES: Record<ChipAccent, { bg: string; border: string; text: string }> = {
+  work:     { bg: Colors.workBgTint3, border: Colors.work,     text: Colors.work },
+  prep:     { bg: Colors.prepIconBg,  border: Colors.prep,     text: Colors.prep },
+  rest:     { bg: Colors.restIconBg,  border: Colors.rest,     text: Colors.rest },
+  strength: { bg: Colors.plumIconBg,  border: Colors.strength, text: Colors.strength },
+};
+
 interface Props {
   label: string;
   icon?: React.ReactNode;
   selected?: boolean;
+  accent?: ChipAccent;
   onPress: () => void;
   style?: ViewStyle;
 }
 
-export default function TypeChip({ label, icon, selected = false, onPress, style }: Props) {
+export default function TypeChip({ label, icon, selected = false, accent = 'work', onPress, style }: Props) {
+  const accentStyle = ACCENT_STYLES[accent];
+  const selectedStyle = selected
+    ? { backgroundColor: accentStyle.bg, borderColor: accentStyle.border }
+    : null;
+
   return (
     <Pressable
-      style={[styles.chip, selected ? styles.selected : styles.default, style]}
+      style={[styles.chip, selected ? selectedStyle : styles.default, style]}
       onPress={onPress}
     >
       {icon}
-      <Text style={[styles.label, selected && styles.labelSelected]}>{label}</Text>
+      <Text style={[styles.label, selected && { color: accentStyle.text }]}>{label}</Text>
     </Pressable>
   );
 }
@@ -36,17 +51,10 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.planeBlack,
     borderColor: Colors.border,
   },
-  selected: {
-    backgroundColor: Colors.workBgTint3,
-    borderColor: Colors.work,
-  },
   label: {
     fontSize: FontSizes.label,
     fontWeight: '600',
     textTransform: 'uppercase',
     color: Colors.textHi,
-  },
-  labelSelected: {
-    color: Colors.work,
   },
 });


### PR DESCRIPTION
## Summary
- Workout type chips on the Build Workout screen now use distinct accent colors when selected
- HIIT keeps the existing `work` (red) accent; Running and Cardio use `prep` (yellow); Strength uses `rest` (green)
- `TypeChip` gains an `accent` prop that drives the selected background, border, label, and icon color

## Test plan
- [ ] Open the Build Workout screen and tap each type chip; verify the selected chip shows the correct accent color (HIIT red, Running/Cardio yellow, Strength green)
- [ ] Confirm unselected chips keep the default dark styling
- [ ] Confirm the icon inside each chip matches the chip's accent color when selected

https://claude.ai/code/session_01LAVmh7G3Tej4yWaAM9LdBr