### PR TITLE
fix: don't show unsaved-changes prompt when Save is tapped

### DIFF
--- a/src/app/build.tsx
+++ b/src/app/build.tsx
@@ -80,6 +80,7 @@ export default function BuildScreen() {
 
   const [p, setP] = useState<Preset>(() => existingPreset ?? { ...DEFAULT })
   const initialPresetRef = useRef<Preset>(existingPreset ?? { ...DEFAULT })
+  const skipRemovePromptRef = useRef(false)
   const isEditing = !!existingPreset
   const [isNameEditing, setIsNameEditing] = useState(!isEditing)
   const nameInputRef = useRef<TextInput>(null)
@@ -138,11 +139,13 @@ export default function BuildScreen() {
 
   const handleSave = () => {
     persist()
+    skipRemovePromptRef.current = true
     router.back()
   }
 
   const handleSaveStart = () => {
     const saved = persist()
+    skipRemovePromptRef.current = true
     startWorkout(saved)
     router.dismiss()
     router.push('/timer')
@@ -160,6 +163,10 @@ export default function BuildScreen() {
     p.cooldownSecs !== initial.cooldownSecs
 
   usePreventRemove(hasUnsavedChanges, ({ data }) => {
+    if (skipRemovePromptRef.current) {
+      navigation.dispatch(data.action)
+      return
+    }
     Alert.alert('Save changes?', 'You have unsaved changes to this workout.', [
       {
         text: 'Discard',


### PR DESCRIPTION
## Summary
- Clicking Save / Save & Start on the Build/Edit Workout screen persisted the preset, but the `usePreventRemove` unsaved-changes alert still fired on the resulting navigation, since `hasUnsavedChanges` was still true at that instant.
- Set a ref right before navigating away after an explicit save so the prevent-remove handler dispatches the navigation directly instead of showing the alert. The prompt still appears when leaving via X / swipe / hardware back with real unsaved edits.

## Test plan
- `npx eslint src/app/build.tsx` — clean
- Manually reasoned through Save, Save & Start, and Discard/Cancel/Save-from-prompt flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)