### PR TITLE
Allow claude[bot] to trigger PR review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Allow PRs opened by the claude[bot] GitHub App (e.g. PRs opened by Claude Code sessions)
+          # to trigger this review workflow.
+          allowed_bots: 'claude[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
The Run Claude Code Review job fails on PR #27 with: "Workflow initiated by non-human actor: claude (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots."

The claude-code-action refuses to run when the PR was opened by a bot actor unless explicitly allowlisted. Since this PR was opened by the claude[bot] GitHub App, add it to allowed_bots.


Claude-Session: https://claude.ai/code/session_011F2jEQK2kEA2Jsij2vPMMn